### PR TITLE
[codex] Add supplier selection case factory

### DIFF
--- a/finrl/meta/data_processors/supplier_selection_cases.py
+++ b/finrl/meta/data_processors/supplier_selection_cases.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from finrl.config_supply_chain import DEFAULT_DEMAND_MEAN
+from finrl.config_supply_chain import DEFAULT_DEMAND_STD
+from finrl.config_supply_chain import DEFAULT_DISRUPTION_PROB
+from finrl.meta.data_processors.processor_supply_chain import SupplyChainDataProcessor
+
+
+GENERATOR_VERSION = "v1"
+OBJECTIVE_PROFILES = [
+    {
+        "profile_id": "balanced_risk_adjusted_cost",
+        "buyer_objective": "Minimize risk-adjusted total cost while maintaining fill rate above 0.95.",
+        "demand_mean_multiplier": 1.0,
+        "demand_std_multiplier": 1.0,
+        "inventory_multiplier": 1.1,
+        "service_level_target": 0.95,
+        "stockout_cost_rate": 0.1,
+        "late_delivery_penalty_rate": 0.05,
+        "quality_rejection_cost_rate": 0.1,
+    },
+    {
+        "profile_id": "lowest_landed_cost",
+        "buyer_objective": "Minimize total landed cost while keeping service levels acceptable.",
+        "demand_mean_multiplier": 0.9,
+        "demand_std_multiplier": 0.8,
+        "inventory_multiplier": 1.25,
+        "service_level_target": 0.9,
+        "stockout_cost_rate": 0.07,
+        "late_delivery_penalty_rate": 0.04,
+        "quality_rejection_cost_rate": 0.08,
+    },
+    {
+        "profile_id": "high_fill_rate_service_protection",
+        "buyer_objective": "Protect fill rate above 0.98 even if procurement costs increase.",
+        "demand_mean_multiplier": 1.05,
+        "demand_std_multiplier": 1.2,
+        "inventory_multiplier": 1.15,
+        "service_level_target": 0.98,
+        "stockout_cost_rate": 0.18,
+        "late_delivery_penalty_rate": 0.08,
+        "quality_rejection_cost_rate": 0.12,
+    },
+    {
+        "profile_id": "lead_time_pressure",
+        "buyer_objective": "Prioritize short lead times because starting inventory is tight.",
+        "demand_mean_multiplier": 1.0,
+        "demand_std_multiplier": 1.1,
+        "inventory_multiplier": 0.65,
+        "service_level_target": 0.96,
+        "stockout_cost_rate": 0.15,
+        "late_delivery_penalty_rate": 0.09,
+        "quality_rejection_cost_rate": 0.1,
+    },
+    {
+        "profile_id": "disruption_resilience",
+        "buyer_objective": "Reduce disruption exposure with resilient suppliers and backup coverage.",
+        "demand_mean_multiplier": 0.95,
+        "demand_std_multiplier": 1.3,
+        "inventory_multiplier": 1.0,
+        "service_level_target": 0.96,
+        "stockout_cost_rate": 0.14,
+        "late_delivery_penalty_rate": 0.07,
+        "quality_rejection_cost_rate": 0.1,
+    },
+    {
+        "profile_id": "capacity_fit_high_demand",
+        "buyer_objective": "Meet elevated demand with allocations that fit supplier capacity limits.",
+        "demand_mean_multiplier": 1.3,
+        "demand_std_multiplier": 1.0,
+        "inventory_multiplier": 0.95,
+        "service_level_target": 0.94,
+        "stockout_cost_rate": 0.12,
+        "late_delivery_penalty_rate": 0.05,
+        "quality_rejection_cost_rate": 0.1,
+    },
+]
+DEFAULT_CASE_OUTPUT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "examples"
+    / "supply_chain"
+    / "supplier_selection_llm"
+    / "outputs"
+    / "cases"
+    / "supplier_selection_cases.jsonl"
+)
+REQUIRED_CASE_FIELDS = {
+    "case_id",
+    "case_type",
+    "seed",
+    "buyer_objective",
+    "demand_context",
+    "supplier_options",
+    "rubric",
+    "metadata",
+}
+REQUIRED_SUPPLIER_FIELDS = {
+    "supplier_id",
+    "base_price",
+    "reliability",
+    "lead_time_days",
+    "capacity",
+    "disruption_probability",
+}
+
+
+def assign_case_split(
+    case_id: str,
+    train_ratio: float = 0.8,
+    validation_ratio: float = 0.1,
+) -> str:
+    split_bucket = int(hashlib.sha256(case_id.encode("utf-8")).hexdigest(), 16) % 100
+    train_cutoff = int(train_ratio * 100)
+    validation_cutoff = train_cutoff + int(validation_ratio * 100)
+    if split_bucket < train_cutoff:
+        return "train"
+    if split_bucket < validation_cutoff:
+        return "validation"
+    return "test"
+
+
+def generate_supplier_selection_cases(
+    case_count: int,
+    seed: int,
+    n_suppliers: int = 3,
+) -> list[dict[str, Any]]:
+    if case_count < 0:
+        raise ValueError("case_count must be non-negative.")
+    if n_suppliers < 1:
+        raise ValueError("n_suppliers must be positive.")
+
+    return [
+        _build_case(
+            case_number=case_number,
+            case_seed=seed + case_number - 1,
+            n_suppliers=n_suppliers,
+        )
+        for case_number in range(1, case_count + 1)
+    ]
+
+
+def write_supplier_selection_cases_jsonl(
+    cases: list[dict[str, Any]],
+    output_path: str | Path,
+) -> Path:
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for case in cases:
+            handle.write(json.dumps(case, sort_keys=True) + "\n")
+    return path
+
+
+def generate_and_write_supplier_selection_cases(
+    case_count: int = 100,
+    seed: int = 1,
+    output_path: str | Path = DEFAULT_CASE_OUTPUT_PATH,
+    n_suppliers: int = 3,
+) -> Path:
+    cases = generate_supplier_selection_cases(
+        case_count=case_count,
+        seed=seed,
+        n_suppliers=n_suppliers,
+    )
+    return write_supplier_selection_cases_jsonl(cases, output_path)
+
+
+def _build_case(case_number: int, case_seed: int, n_suppliers: int) -> dict[str, Any]:
+    case_id = f"supplier_case_{case_number:06d}"
+    objective_profile = _objective_profile_for_case(case_number)
+    rng = np.random.default_rng(case_seed)
+    demand_mean = float(
+        DEFAULT_DEMAND_MEAN
+        * float(objective_profile["demand_mean_multiplier"])
+        * rng.uniform(0.8, 1.2)
+    )
+    demand_std = float(
+        DEFAULT_DEMAND_STD
+        * float(objective_profile["demand_std_multiplier"])
+        * rng.uniform(0.7, 1.4)
+    )
+
+    return {
+        "case_id": case_id,
+        "case_type": "supplier_selection",
+        "seed": int(case_seed),
+        "buyer_objective": str(objective_profile["buyer_objective"]),
+        "demand_context": {
+            "demand_mean": _round_float(demand_mean),
+            "demand_std": _round_float(demand_std),
+            "initial_inventory": _round_float(
+                demand_mean
+                * float(objective_profile["inventory_multiplier"])
+                * rng.uniform(0.8, 1.4)
+            ),
+            "initial_budget": 100000.0,
+            "horizon_days": 60,
+            "service_level_target": float(objective_profile["service_level_target"]),
+            "stockout_cost_rate": float(objective_profile["stockout_cost_rate"]),
+            "late_delivery_penalty_rate": float(
+                objective_profile["late_delivery_penalty_rate"]
+            ),
+            "quality_rejection_cost_rate": float(
+                objective_profile["quality_rejection_cost_rate"]
+            ),
+        },
+        "supplier_options": _build_supplier_options(case_seed, n_suppliers),
+        "rubric": {
+            "dimensions": [
+                "total_landed_cost",
+                "reliability_and_service_risk",
+                "lead_time_suitability",
+                "capacity_fit",
+                "disruption_resilience",
+            ],
+            "score_range": [0.0, 1.0],
+            "aggregation": "equal_weight_mean",
+        },
+        "metadata": {
+            "generator_version": GENERATOR_VERSION,
+            "objective_profile": str(objective_profile["profile_id"]),
+            "split": assign_case_split(case_id),
+        },
+    }
+
+
+def _objective_profile_for_case(case_number: int) -> dict[str, str | float]:
+    return OBJECTIVE_PROFILES[(case_number - 1) % len(OBJECTIVE_PROFILES)]
+
+
+def _build_supplier_options(case_seed: int, n_suppliers: int) -> list[dict[str, Any]]:
+    supplier_rows = SupplyChainDataProcessor(seed=case_seed).generate_supplier_data(
+        n_suppliers=n_suppliers,
+        n_periods=1,
+    )
+    supplier_rows = supplier_rows.sort_values("supplier_id")
+    suppliers = []
+    for row in supplier_rows.to_dict(orient="records"):
+        suppliers.append(
+            {
+                "supplier_id": str(row["supplier_id"]),
+                "base_price": _round_float(row["price"]),
+                "reliability": _round_float(row["reliability"]),
+                "lead_time_days": max(1, int(round(float(row["lead_time"])))),
+                "capacity": _round_float(row["capacity"]),
+                "disruption_probability": float(DEFAULT_DISRUPTION_PROB),
+            }
+        )
+    return suppliers
+
+
+def _round_float(value: float) -> float:
+    return float(round(float(value), 6))

--- a/unit_tests/data_processors/test_supplier_selection_cases.py
+++ b/unit_tests/data_processors/test_supplier_selection_cases.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from finrl.meta.data_processors.supplier_selection_cases import (
+    DEFAULT_CASE_OUTPUT_PATH,
+    OBJECTIVE_PROFILES,
+    REQUIRED_CASE_FIELDS,
+    REQUIRED_SUPPLIER_FIELDS,
+    assign_case_split,
+    generate_and_write_supplier_selection_cases,
+    generate_supplier_selection_cases,
+    write_supplier_selection_cases_jsonl,
+)
+
+
+def test_supplier_selection_cases_are_deterministic_for_fixed_seed():
+    first = generate_supplier_selection_cases(case_count=5, seed=17)
+    second = generate_supplier_selection_cases(case_count=5, seed=17)
+
+    assert first == second
+
+
+def test_supplier_selection_case_schema_and_supplier_fields():
+    case = generate_supplier_selection_cases(case_count=1, seed=23)[0]
+
+    assert REQUIRED_CASE_FIELDS.issubset(case)
+    assert case["case_id"] == "supplier_case_000001"
+    assert case["case_type"] == "supplier_selection"
+    assert case["seed"] == 23
+    assert case["buyer_objective"]
+    assert case["metadata"]["objective_profile"] in {
+        profile["profile_id"] for profile in OBJECTIVE_PROFILES
+    }
+    assert "service_level_target" in case["demand_context"]
+    assert case["metadata"]["generator_version"] == "v1"
+    assert case["metadata"]["split"] == assign_case_split(case["case_id"])
+    assert case["rubric"]["aggregation"] == "equal_weight_mean"
+
+    assert len(case["supplier_options"]) >= 3
+    for supplier in case["supplier_options"]:
+        assert REQUIRED_SUPPLIER_FIELDS.issubset(supplier)
+        assert supplier["supplier_id"].startswith("SUP_")
+        assert supplier["base_price"] > 0.0
+        assert 0.0 <= supplier["reliability"] <= 1.0
+        assert supplier["lead_time_days"] >= 1
+        assert supplier["capacity"] > 0.0
+        assert 0.0 <= supplier["disruption_probability"] <= 1.0
+
+
+def test_generate_one_hundred_valid_supplier_selection_cases():
+    cases = generate_supplier_selection_cases(case_count=100, seed=31)
+
+    assert len(cases) == 100
+    assert len({case["case_id"] for case in cases}) == 100
+    assert all(case["case_type"] == "supplier_selection" for case in cases)
+    assert all(REQUIRED_CASE_FIELDS.issubset(case) for case in cases)
+
+
+def test_one_hundred_cases_cover_multiple_objective_profiles():
+    cases = generate_supplier_selection_cases(case_count=100, seed=31)
+
+    objective_profiles = {case["metadata"]["objective_profile"] for case in cases}
+    buyer_objectives = {case["buyer_objective"] for case in cases}
+
+    assert objective_profiles == {profile["profile_id"] for profile in OBJECTIVE_PROFILES}
+    assert len(buyer_objectives) == len(OBJECTIVE_PROFILES)
+
+
+def test_split_assignment_is_deterministic_by_case_id_only():
+    case_id = "supplier_case_000042"
+
+    assert assign_case_split(case_id) == assign_case_split(case_id)
+    assert generate_supplier_selection_cases(case_count=42, seed=1)[-1]["metadata"][
+        "split"
+    ] == generate_supplier_selection_cases(case_count=42, seed=999)[-1]["metadata"][
+        "split"
+    ]
+
+
+def test_objective_profile_assignment_is_deterministic_by_case_number_only():
+    seed_one_cases = generate_supplier_selection_cases(case_count=12, seed=1)
+    seed_two_cases = generate_supplier_selection_cases(case_count=12, seed=999)
+
+    assert [
+        case["metadata"]["objective_profile"] for case in seed_one_cases
+    ] == [
+        case["metadata"]["objective_profile"] for case in seed_two_cases
+    ]
+
+
+def test_supplier_selection_cases_can_be_written_as_jsonl(tmp_path):
+    cases = generate_supplier_selection_cases(case_count=3, seed=43)
+    output_path = tmp_path / "cases" / "supplier_selection_cases.jsonl"
+
+    written_path = write_supplier_selection_cases_jsonl(cases, output_path)
+
+    assert written_path == output_path
+    lines = output_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    assert '"case_id": "supplier_case_000001"' in lines[0]
+
+
+def test_generate_and_write_supplier_selection_cases_uses_output_layout(tmp_path):
+    output_path = tmp_path / DEFAULT_CASE_OUTPUT_PATH.name
+
+    written_path = generate_and_write_supplier_selection_cases(
+        case_count=4,
+        seed=47,
+        output_path=output_path,
+    )
+
+    assert written_path == output_path
+    assert len(output_path.read_text(encoding="utf-8").splitlines()) == 4
+    assert str(DEFAULT_CASE_OUTPUT_PATH).replace("\\", "/").endswith(
+        "examples/supply_chain/supplier_selection_llm/outputs/cases/supplier_selection_cases.jsonl"
+    )


### PR DESCRIPTION
## Summary

- Add a deterministic synthetic supplier-selection case factory for issue #2.
- Generate stable case IDs, hash-based dataset splits, supplier options from the existing supply-chain data processor, and JSONL output under the ignored supplier-selection LLM output layout.
- Add deterministic buyer-objective profiles so generated cases cover balanced cost, lowest landed cost, fill-rate protection, lead-time pressure, disruption resilience, and high-demand capacity fit without changing downstream scoring.

## Scope Notes

Candidate actions, outcome evaluation, best-action selection, and objective-specific scoring remain intentionally deferred to issues #3 and #4.

## Verification

- `python -m pytest unit_tests\data_processors\test_supply_chain_processor.py unit_tests\data_processors\test_supplier_selection_cases.py unit_tests\environments\test_supply_chain_envs.py`
- Result: 15 passed. Existing pytest-asyncio deprecation warning still appears.